### PR TITLE
Feature: Schedule 추가, 삭제할 때 그룹 시간표 갱신 기능 추가 및 버그 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'
 
-    implementation 'com.github.cometj03.ComposeTimeTable:final:0.0.5'
+    implementation 'com.github.cometj03.ComposeTimeTable:final:0.0.6'
     implementation "androidx.compose.runtime:runtime-livedata:$compose_ui_version"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'
 
-    implementation 'com.github.cometj03.ComposeTimeTable:final:0.0.4'
+    implementation 'com.github.cometj03.ComposeTimeTable:final:0.0.5'
     implementation "androidx.compose.runtime:runtime-livedata:$compose_ui_version"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'
 
-    implementation 'com.github.cometj03.ComposeTimeTable:final:0.0.3'
+    implementation 'com.github.cometj03.ComposeTimeTable:final:0.0.4'
     implementation "androidx.compose.runtime:runtime-livedata:$compose_ui_version"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
@@ -25,8 +25,10 @@ public class FirebaseGroup {
                         f.onFailed("그룹 정보를 가져오는 도중 오류가 발생했습니다.");
                         return;
                     }
-                    if (task.getResult().isEmpty())
+                    if (task.getResult().isEmpty()) {
+                        s.onSuccess(List.of());
                         return;
+                    }
                     List<String> groupIdList = new ArrayList<>();
                     for (DocumentSnapshot doc : task.getResult())
                         groupIdList.add(doc.getReference().getId());

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
@@ -1,8 +1,10 @@
 package com.example.woomansi.data.repository;
 
 import com.example.woomansi.data.model.GroupModel;
-import com.example.woomansi.data.model.ScheduleDataWrapper;
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FieldPath;
+import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QuerySnapshot;
 
@@ -26,7 +28,7 @@ public class FirebaseGroup {
 
     // 현재 유저가 가입되어 있는 그룹을 찾는 함수
     public static void getGroupIds(String userId, OnFindGroupIdSuccessListener s, OnFailedListener f) {
-        getGroups(userId, querySnapshot -> {
+        getGroupQueries(userId, querySnapshot -> {
             List<String> groupIdList = new ArrayList<>();
             for (DocumentSnapshot doc : querySnapshot)
                 groupIdList.add(doc.getId());
@@ -59,7 +61,7 @@ public class FirebaseGroup {
     }
 
     public static void getGroupModelsWithChangeListener(String userId, OnFindGroupModelSuccessListener s, OnFailedListener f) {
-        getGroups(userId, querySnapshot -> {
+        getGroupQueries(userId, querySnapshot -> {
             List<GroupModel> groupModelList = new ArrayList<>();
             for (DocumentSnapshot doc : querySnapshot)
                 groupModelList.add(doc.toObject(GroupModel.class));
@@ -87,7 +89,31 @@ public class FirebaseGroup {
                 });
     }
 
-    private static void getGroups(String userId, OnGetGroupQuerySuccessListener s, OnFailedListener f) {
+    // groupId 그룹에 멤버 한 명 추가
+    public static void addMember(String groupId, String memberId, OnSuccessListener<Void> s, OnFailedListener f) {
+        FirebaseFirestore
+                .getInstance()
+                .collection(COLLECTION_NAME)
+                .document(groupId)
+                .update("memberList", FieldValue.arrayUnion(groupId))
+                .addOnSuccessListener(s)
+                .addOnFailureListener(e ->
+                        f.onFailed("그룹에 추가되지 않았습니다.\n" + e.getMessage()));
+    }
+
+    // groupId 그룹에 멤버 한 명 탈퇴
+    public static void removeMember(String groupId, String memberId, OnSuccessListener<Void> s, OnFailedListener f) {
+        FirebaseFirestore
+                .getInstance()
+                .collection(COLLECTION_NAME)
+                .document(groupId)
+                .update("memberList", FieldValue.arrayRemove(groupId))
+                .addOnSuccessListener(s)
+                .addOnFailureListener(e ->
+                        f.onFailed("그룹에 추가되지 않았습니다.\n" + e.getMessage()));
+    }
+
+    private static void getGroupQueries(String userId, OnGetGroupQuerySuccessListener s, OnFailedListener f) {
         FirebaseFirestore
                 .getInstance()
                 .collection(COLLECTION_NAME)

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
@@ -1,0 +1,36 @@
+package com.example.woomansi.data.repository;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FirebaseGroup {
+    private static final String COLLECTION_NAME = "groups";
+
+    public interface OnFindGroupSuccess {
+        void onSuccess(List<String> groupIdList);
+    }
+
+    // 현재 유저가 가입되어 있는 그룹을 찾는 함수
+    public static void getGroups(String userId, OnFindGroupSuccess s, OnFailedListener f) {
+        FirebaseFirestore
+                .getInstance()
+                .collection(COLLECTION_NAME)
+                .whereArrayContains("memberList", userId)
+                .get()
+                .addOnCompleteListener(task -> {
+                    if (!task.isSuccessful()) {
+                        f.onFailed("그룹 정보를 가져오는 도중 오류가 발생했습니다.");
+                        return;
+                    }
+                    if (task.getResult().isEmpty())
+                        return;
+                    List<String> groupIdList = new ArrayList<>();
+                    for (DocumentSnapshot doc : task.getResult())
+                        groupIdList.add(doc.getReference().getId());
+                    s.onSuccess(groupIdList);
+                });
+    }
+}

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
@@ -1,7 +1,10 @@
 package com.example.woomansi.data.repository;
 
+import com.example.woomansi.data.model.GroupModel;
+import com.example.woomansi.data.model.ScheduleDataWrapper;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,12 +12,82 @@ import java.util.List;
 public class FirebaseGroup {
     private static final String COLLECTION_NAME = "groups";
 
-    public interface OnFindGroupSuccess {
+    public interface OnFindGroupIdSuccessListener {
         void onSuccess(List<String> groupIdList);
     }
 
+    public interface OnFindGroupModelSuccessListener {
+        void onSuccess(List<GroupModel> groupModelList);
+    }
+
+    private interface OnGetGroupQuerySuccessListener {
+        void onSuccess(QuerySnapshot querySnapshot);
+    }
+
     // 현재 유저가 가입되어 있는 그룹을 찾는 함수
-    public static void getGroups(String userId, OnFindGroupSuccess s, OnFailedListener f) {
+    public static void getGroupIds(String userId, OnFindGroupIdSuccessListener s, OnFailedListener f) {
+        getGroups(userId, querySnapshot -> {
+            List<String> groupIdList = new ArrayList<>();
+            for (DocumentSnapshot doc : querySnapshot)
+                groupIdList.add(doc.getId());
+            s.onSuccess(groupIdList);
+        }, f);
+    }
+
+    public static void getGroupIdsWithChangeListener(String userId, OnFindGroupIdSuccessListener s, OnFailedListener f) {
+        getGroupIds(userId, s, f);
+
+        // 리스너 달아주는 코드
+        FirebaseFirestore
+                .getInstance()
+                .collection(COLLECTION_NAME)
+                .whereArrayContains("memberList", userId)
+                .addSnapshotListener((snapshot, error) -> {
+                    if (error != null) {
+                        f.onFailed("Data Listen Failed\n" + error.getMessage());
+                        return;
+                    }
+                    if (snapshot != null && !snapshot.isEmpty()) {
+                        List<String> groupIdList = new ArrayList<>();
+                        for (DocumentSnapshot doc : snapshot.getDocuments())
+                            groupIdList.add(doc.getId());
+                        s.onSuccess(groupIdList);
+                    } else {
+                        f.onFailed("Current Data: null");
+                    }
+                });
+    }
+
+    public static void getGroupModelsWithChangeListener(String userId, OnFindGroupModelSuccessListener s, OnFailedListener f) {
+        getGroups(userId, querySnapshot -> {
+            List<GroupModel> groupModelList = new ArrayList<>();
+            for (DocumentSnapshot doc : querySnapshot)
+                groupModelList.add(doc.toObject(GroupModel.class));
+            s.onSuccess(groupModelList);
+        }, f);
+
+        // 리스너 달아주는 코드
+        FirebaseFirestore
+                .getInstance()
+                .collection(COLLECTION_NAME)
+                .whereArrayContains("memberList", userId)
+                .addSnapshotListener((snapshot, error) -> {
+                    if (error != null) {
+                        f.onFailed("Data Listen Failed\n" + error.getMessage());
+                        return;
+                    }
+                    if (snapshot != null && !snapshot.isEmpty()) {
+                        List<GroupModel> groupModelList = new ArrayList<>();
+                        for (DocumentSnapshot doc : snapshot.getDocuments())
+                            groupModelList.add(doc.toObject(GroupModel.class));
+                        s.onSuccess(groupModelList);
+                    } else {
+                        f.onFailed("Current Data: null");
+                    }
+                });
+    }
+
+    private static void getGroups(String userId, OnGetGroupQuerySuccessListener s, OnFailedListener f) {
         FirebaseFirestore
                 .getInstance()
                 .collection(COLLECTION_NAME)
@@ -25,14 +98,7 @@ public class FirebaseGroup {
                         f.onFailed("그룹 정보를 가져오는 도중 오류가 발생했습니다.");
                         return;
                     }
-                    if (task.getResult().isEmpty()) {
-                        s.onSuccess(List.of());
-                        return;
-                    }
-                    List<String> groupIdList = new ArrayList<>();
-                    for (DocumentSnapshot doc : task.getResult())
-                        groupIdList.add(doc.getReference().getId());
-                    s.onSuccess(groupIdList);
+                    s.onSuccess(task.getResult());
                 });
     }
 }

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroupExit.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroupExit.java
@@ -65,7 +65,7 @@ public class FirebaseGroupExit {
 
             //1. 그룹 스케쥴 업데이트
             //2. 먼저 멤버의 스케쥴을 불러옴
-            FirebaseSchedules.getSchedules(
+            FirebaseUserSchedule.getSchedules(
                 memberId,
                 dayNameList,
                 scheduleMap -> {

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroupSchedule.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroupSchedule.java
@@ -41,6 +41,28 @@ public class FirebaseGroupSchedule {
         }, f);
     }
 
+    // 추가된 시간표만 그룹 시간표에 합쳐주고, 업데이트하는 함수
+    public static void unionSchedule(
+            String groupId,
+            String dayName,
+            ScheduleModel scheduleModel,
+            OnUnionSuccessListener s,
+            OnFailedListener f
+    ) {
+        fetchGroupSchedule(groupId, null, groupSchedule -> {
+            // 해당 요일에 맞는 데이터를 불러와서 계산
+            List<Integer> result = CalculationUtil.unionLists(
+                    groupSchedule.get(dayName), List.of(scheduleModel));
+
+            FieldPath path = FieldPath.of(PATH_WRAPPER, dayName);
+            // 해당 요일의 값을 업데이트
+            FirebaseFirestore.getInstance()
+                    .collection(COLLECTION_NAME).document(groupId).update(path, result)
+                    .addOnSuccessListener(a -> s.onSuccess())
+                    .addOnFailureListener(e -> f.onFailed(e.getMessage()));
+        }, f);
+    }
+
     // 기존의 그룹 시간표를 불러와서 scheduleData를 계산하여 빼고, 업데이트하는 함수
     public static void minusSchedules(
         String groupId,

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroupSchedule.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroupSchedule.java
@@ -4,9 +4,11 @@ import com.example.woomansi.data.model.GroupTimeTableWrapper;
 import com.example.woomansi.data.model.ScheduleModel;
 import com.example.woomansi.util.CalculationUtil;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FieldPath;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +16,7 @@ import java.util.Map;
 
 public class FirebaseGroupSchedule {
     private static final String COLLECTION_NAME = "group_schedules";
+    private static final String PATH_WRAPPER = "groupTimeTable";
 
     public interface OnFetchSuccessListener {
         void onSuccess(Map<String, List<Integer>> groupSchedule);
@@ -50,6 +53,28 @@ public class FirebaseGroupSchedule {
         fetchGroupSchedule(groupId, dayNames, groupSchedule -> {
             Map<String, List<Integer>> result = calculateWith(groupSchedule, scheduleData, false);
             updateGroupSchedule(groupId, result, s, f);
+        }, f);
+    }
+
+    // 그룹 시간표의 일정 하나만 계산하여 빼고, 업데이트하는 함수
+    public static void minusSchedule(
+            String groupId,
+            String dayName,
+            ScheduleModel scheduleModel,
+            OnUnionSuccessListener s,
+            OnFailedListener f
+    ) {
+        fetchGroupSchedule(groupId, null, groupSchedule -> {
+            // 해당 요일에 맞는 데이터를 불러와서 계산
+            List<Integer> result = CalculationUtil.minusLists(
+                    groupSchedule.get(dayName), List.of(scheduleModel));
+
+            FieldPath path = FieldPath.of(PATH_WRAPPER, dayName);
+            // 해당 요일의 값을 업데이트
+            FirebaseFirestore.getInstance()
+                    .collection(COLLECTION_NAME).document(groupId).update(path, result)
+                    .addOnSuccessListener(a -> s.onSuccess())
+                    .addOnFailureListener(e -> f.onFailed(e.getMessage()));
         }, f);
     }
 

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseUserSchedule.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseUserSchedule.java
@@ -3,6 +3,7 @@ package com.example.woomansi.data.repository;
 import com.example.woomansi.data.model.ScheduleDataWrapper;
 import com.example.woomansi.data.model.ScheduleModel;
 import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldPath;
@@ -71,7 +72,8 @@ public class FirebaseUserSchedule {
             String scheduleId,
             String dayName,
             ScheduleModel schedule,
-            OnCompleteListener<Void> s
+            OnCompleteListener<Void> s,
+            OnFailedListener f
     ) {
         // schedules내의 특정 dayName의 경로를 가리킴. (schedules: ScheduleDataWrapper의 멤버 변수 이름)
         FieldPath path = FieldPath.of("schedules", dayName);
@@ -82,14 +84,17 @@ public class FirebaseUserSchedule {
                 .collection(COLLECTION_NAME)
                 .document(scheduleId)
                 .update(path, FieldValue.arrayUnion(schedule))
-                .addOnCompleteListener(s);
+                .addOnCompleteListener(s)
+                .addOnFailureListener(e ->
+                        f.onFailed("일정을 추가하지 못했습니다\n" + e.getMessage()));
     }
 
     public static void deleteSchedule(
             String scheduleId,
             String dayName,
             ScheduleModel schedule,
-            OnCompleteListener<Void> s
+            OnSuccessListener<Void> s,
+            OnFailedListener f
     ) {
         FieldPath path = FieldPath.of("schedules", dayName);
 
@@ -98,7 +103,9 @@ public class FirebaseUserSchedule {
                 .collection(COLLECTION_NAME)
                 .document(scheduleId)
                 .update(path, FieldValue.arrayRemove(schedule))
-                .addOnCompleteListener(s);
+                .addOnSuccessListener(s)
+                .addOnFailureListener(e ->
+                        f.onFailed("일정을 삭제하지 못했습니다\n" + e.getMessage()));
     }
 
     private static void initializeSchedule(

--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseUserSchedule.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseUserSchedule.java
@@ -53,6 +53,20 @@ public class FirebaseUserSchedule {
                 }
             });
 
+
+    }
+
+    public static void getSchedulesWithChangeListener(
+            String scheduleId,
+            List<String> dayNameList, // 기본: 월 ~ 일
+            OnLoadSuccessListener s,
+            OnFailedListener f
+    ) {
+        getSchedules(scheduleId, dayNameList, s, f);
+
+        DocumentReference ref = FirebaseFirestore.getInstance()
+                .collection(COLLECTION_NAME).document(scheduleId);
+
         // 데이터 변경사항 리스너 달아주는 코드
         ref.addSnapshotListener((snapshot, error) -> {
             if (error != null) {

--- a/app/src/main/java/com/example/woomansi/ui/adapter/GroupListAdapter.java
+++ b/app/src/main/java/com/example/woomansi/ui/adapter/GroupListAdapter.java
@@ -31,6 +31,11 @@ public class GroupListAdapter extends BaseAdapter {
         void onImageItemClick(int a_imageResId) ;
     }
 
+    public void setGroupModelList(ArrayList<GroupModel> groupModelList) {
+        this.group = groupModelList;
+        notifyDataSetChanged();
+    }
+
     @Override
     public int getCount() {
       return group.size();

--- a/app/src/main/java/com/example/woomansi/ui/screen/group/GroupCreateActivity.java
+++ b/app/src/main/java/com/example/woomansi/ui/screen/group/GroupCreateActivity.java
@@ -9,24 +9,16 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.woomansi.R;
 import com.example.woomansi.data.model.GroupModel;
-import com.example.woomansi.data.model.GroupTimeTableWrapper;
 import com.example.woomansi.data.repository.FirebaseGroupCreate;
 import com.example.woomansi.data.repository.FirebaseGroupSchedule;
-import com.example.woomansi.data.repository.FirebaseSchedules;
-import com.example.woomansi.util.CalculationUtil;
+import com.example.woomansi.data.repository.FirebaseUserSchedule;
 import com.example.woomansi.util.UserCache;
 import com.google.android.material.appbar.MaterialToolbar;
 
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TimeZone;
 
 
 public class GroupCreateActivity extends AppCompatActivity {
@@ -84,7 +76,7 @@ public class GroupCreateActivity extends AppCompatActivity {
                 documentId -> {
                     // 방금 생성한 그룹의 documentId를 인자로 건네줌
                     // 먼저 그룹장(지금 사용자)의 개인 스케줄 데이터를 받아오기
-                    FirebaseSchedules.getSchedules(
+                    FirebaseUserSchedule.getSchedules(
                             userId,
                             dayNameList,
                             scheduleMap -> {

--- a/app/src/main/java/com/example/woomansi/ui/screen/group/GroupDetailActivity.kt
+++ b/app/src/main/java/com/example/woomansi/ui/screen/group/GroupDetailActivity.kt
@@ -68,7 +68,7 @@ class GroupDetailActivity : AppCompatActivity() {
             tableData.value?.let {
                 ComposeTimeTable(
                         timeTableData = it,
-                        onCellClick = { _, _ -> },
+                        onCellClick = { _, _, _ -> },
                         modifier = Modifier.verticalScroll(scrollState)
                 )
             }

--- a/app/src/main/java/com/example/woomansi/ui/screen/group/GroupDetailActivity.kt
+++ b/app/src/main/java/com/example/woomansi/ui/screen/group/GroupDetailActivity.kt
@@ -68,7 +68,7 @@ class GroupDetailActivity : AppCompatActivity() {
             tableData.value?.let {
                 ComposeTimeTable(
                         timeTableData = it,
-                        onCellClick = {},
+                        onCellClick = { _, _ -> },
                         modifier = Modifier.verticalScroll(scrollState)
                 )
             }

--- a/app/src/main/java/com/example/woomansi/ui/screen/main/Main1Fragment.kt
+++ b/app/src/main/java/com/example/woomansi/ui/screen/main/Main1Fragment.kt
@@ -1,12 +1,14 @@
 package com.example.woomansi.ui.screen.main
 
 import android.app.TimePickerDialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.*
+import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.livedata.observeAsState
@@ -61,7 +63,12 @@ class Main1Fragment : Fragment(R.layout.fragment_main1) {
                 tableData.value?.let {
                     ComposeTimeTable(
                         timeTableData = it,
-                        onCellClick = { _, _ -> Unit },
+                        onCellClick = { column, row, _ ->
+                            val key = dayNameList[column]
+                            viewModel.scheduleMap[key]?.get(row)?.let { scheduleModel ->
+                                showScheduleDialog(key, scheduleModel)
+                            }
+                        },
                         modifier = Modifier.verticalScroll(scrollState)
                     )
                 }
@@ -84,8 +91,27 @@ class Main1Fragment : Fragment(R.layout.fragment_main1) {
         }
     }
 
-    private fun showDeleteDialog(scheduleModel: ScheduleModel) {
+    private fun showScheduleDialog(dayName: String, scheduleModel: ScheduleModel) {
+        AlertDialog.Builder(requireContext())
+            .setTitle("일정 정보")
+            .setMessage("${scheduleModel.name}\n\n${scheduleModel.description}")
+            .setPositiveButton("확인", null)
+            .setNegativeButton("삭제하기") { _, _ -> showDeleteDialog(dayName, scheduleModel)}
+            .create()
+            .show()
+    }
 
+    private fun showDeleteDialog(dayName: String, scheduleModel: ScheduleModel) {
+        AlertDialog.Builder(requireContext())
+            .setIcon(android.R.drawable.ic_dialog_alert)
+            .setTitle("알림")
+            .setMessage("정말 \"${scheduleModel.name}\" 일정을 삭제하시겠습니까?")
+            .setPositiveButton("확인") { _, _, ->
+                viewModel.deleteSchedule(dayName, scheduleModel)
+            }
+            .setNegativeButton("취소", null)
+            .create()
+            .show()
     }
 
     private fun bottomSheetSetting() {

--- a/app/src/main/java/com/example/woomansi/ui/screen/main/Main1Fragment.kt
+++ b/app/src/main/java/com/example/woomansi/ui/screen/main/Main1Fragment.kt
@@ -189,6 +189,10 @@ class Main1Fragment : Fragment(R.layout.fragment_main1) {
             showToast("요일을 선택해주세요")
             return false
         }
+        if (startTime.isBefore(LocalTime.of(6, 0))) {
+            showToast("오전 6시 이후로 설정해주세요")
+            return false
+        }
         if (!startTime.isBefore(endTime)) {
             showToast("시작 시간이 종료 시간보다 앞서 있어야 합니다")
             return false

--- a/app/src/main/java/com/example/woomansi/ui/screen/main/Main1Fragment.kt
+++ b/app/src/main/java/com/example/woomansi/ui/screen/main/Main1Fragment.kt
@@ -17,6 +17,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.cometj03.composetimetable.ComposeTimeTable
 import com.example.woomansi.R
+import com.example.woomansi.data.model.ScheduleModel
 import com.example.woomansi.ui.viewmodel.Main1ViewModel
 import com.example.woomansi.util.TimeFormatUtil
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -60,7 +61,7 @@ class Main1Fragment : Fragment(R.layout.fragment_main1) {
                 tableData.value?.let {
                     ComposeTimeTable(
                         timeTableData = it,
-                        onCellClick = {},
+                        onCellClick = { _, _ -> Unit },
                         modifier = Modifier.verticalScroll(scrollState)
                     )
                 }
@@ -81,6 +82,10 @@ class Main1Fragment : Fragment(R.layout.fragment_main1) {
             }
             scheduleCreateDialog.setCancelable(true)
         }
+    }
+
+    private fun showDeleteDialog(scheduleModel: ScheduleModel) {
+
     }
 
     private fun bottomSheetSetting() {

--- a/app/src/main/java/com/example/woomansi/ui/screen/main/Main1Fragment.kt
+++ b/app/src/main/java/com/example/woomansi/ui/screen/main/Main1Fragment.kt
@@ -93,8 +93,9 @@ class Main1Fragment : Fragment(R.layout.fragment_main1) {
 
     private fun showScheduleDialog(dayName: String, scheduleModel: ScheduleModel) {
         AlertDialog.Builder(requireContext())
-            .setTitle("일정 정보")
-            .setMessage("${scheduleModel.name}\n\n${scheduleModel.description}")
+            .setTitle(scheduleModel.name)
+            .setMessage("${scheduleModel.startTime} ~ ${scheduleModel.endTime}\n\n" +
+                    scheduleModel.description)
             .setPositiveButton("확인", null)
             .setNegativeButton("삭제하기") { _, _ -> showDeleteDialog(dayName, scheduleModel)}
             .create()

--- a/app/src/main/java/com/example/woomansi/ui/screen/main/Main2Fragment.java
+++ b/app/src/main/java/com/example/woomansi/ui/screen/main/Main2Fragment.java
@@ -26,7 +26,7 @@ import androidx.fragment.app.Fragment;
 import com.example.woomansi.R;
 import com.example.woomansi.data.model.GroupModel;
 import com.example.woomansi.data.repository.FirebaseGroupSchedule;
-import com.example.woomansi.data.repository.FirebaseSchedules;
+import com.example.woomansi.data.repository.FirebaseUserSchedule;
 import com.example.woomansi.ui.adapter.GroupListAdapter;
 import com.example.woomansi.ui.screen.group.GroupCreateActivity;
 import com.example.woomansi.ui.screen.group.GroupDetailActivity;
@@ -201,7 +201,7 @@ public class Main2Fragment extends Fragment {
 
 
                                 //멤버 스케쥴 불러오기
-                                FirebaseSchedules.getSchedules(
+                                FirebaseUserSchedule.getSchedules(
                                     userId,
                                     dayNameList,
                                     scheduleMap -> {

--- a/app/src/main/java/com/example/woomansi/ui/screen/vote/VoteCreateActivity.kt
+++ b/app/src/main/java/com/example/woomansi/ui/screen/vote/VoteCreateActivity.kt
@@ -55,7 +55,7 @@ class VoteCreateActivity : AppCompatActivity() {
                 tableData.value?.let {
                     ComposeTimeTable(
                             timeTableData = it,
-                            onCellClick = { _, _ -> },
+                            onCellClick = { _, _, _ -> },
                             modifier = Modifier.verticalScroll(scrollState)
                     )
                 }

--- a/app/src/main/java/com/example/woomansi/ui/screen/vote/VoteCreateActivity.kt
+++ b/app/src/main/java/com/example/woomansi/ui/screen/vote/VoteCreateActivity.kt
@@ -55,7 +55,7 @@ class VoteCreateActivity : AppCompatActivity() {
                 tableData.value?.let {
                     ComposeTimeTable(
                             timeTableData = it,
-                            onCellClick = {},
+                            onCellClick = { _, _ -> },
                             modifier = Modifier.verticalScroll(scrollState)
                     )
                 }

--- a/app/src/main/java/com/example/woomansi/ui/viewmodel/Main1ViewModel.java
+++ b/app/src/main/java/com/example/woomansi/ui/viewmodel/Main1ViewModel.java
@@ -136,7 +136,6 @@ public class Main1ViewModel extends ViewModel {
                 },
                 errorMsg -> setError(errorMsg)
         );
-        // TODO: 그룹 스케줄에서 빼주기
     }
 
     private void loadSchedules(List<String> dayNameList) {
@@ -145,7 +144,7 @@ public class Main1ViewModel extends ViewModel {
             return;
 
         isLoading.setValue(true);
-        FirebaseUserSchedule.getSchedules(
+        FirebaseUserSchedule.getSchedulesWithChangeListener(
             user.getIdToken(),
             dayNameList,
             scheduleMap -> {

--- a/app/src/main/java/com/example/woomansi/ui/viewmodel/Main1ViewModel.java
+++ b/app/src/main/java/com/example/woomansi/ui/viewmodel/Main1ViewModel.java
@@ -58,7 +58,8 @@ public class Main1ViewModel extends ViewModel {
                 user.getIdToken(),
                 dayOfWeekName,
                 schedule,
-                task -> errorMessage.setValue(null)
+                task -> errorMessage.setValue(null),
+                errorMsg -> errorMessage.setValue(errorMsg)
         );
 
         //현재 유저가 들어있는 그룹을 찾음

--- a/app/src/main/java/com/example/woomansi/ui/viewmodel/Main1ViewModel.java
+++ b/app/src/main/java/com/example/woomansi/ui/viewmodel/Main1ViewModel.java
@@ -1,8 +1,5 @@
 package com.example.woomansi.ui.viewmodel;
 
-import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
-
-import android.util.Log;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
@@ -12,16 +9,11 @@ import com.example.woomansi.data.model.UserModel;
 import com.example.woomansi.data.repository.FirebaseGroup;
 import com.example.woomansi.data.repository.FirebaseGroupSchedule;
 import com.example.woomansi.data.repository.FirebaseUserSchedule;
-import com.example.woomansi.util.DayNameList;
 import com.example.woomansi.util.ScheduleTypeTransform;
 import com.example.woomansi.util.TimeFormatUtil;
 import com.example.woomansi.util.UserCache;
-import com.google.firebase.firestore.DocumentReference;
-import com.google.firebase.firestore.DocumentSnapshot;
-import com.google.firebase.firestore.FirebaseFirestore;
+
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -71,7 +63,7 @@ public class Main1ViewModel extends ViewModel {
                 schedule,
                 a -> {
                     // 현재 유저가 가입되어 있는 그룹을 찾고 그룹 document id 리스트를 반환함
-                    FirebaseGroup.getGroups(
+                    FirebaseGroup.getGroupIds(
                             user.getIdToken(),
                             groupIdList -> {
                                 final int[] successCount = {0}; // 아래 deleteSchedule()에서 주석 확인
@@ -109,7 +101,7 @@ public class Main1ViewModel extends ViewModel {
                 schedule,
                 a -> {
                     // 현재 유저가 가입되어 있는 그룹을 찾고 그룹 document id 리스트를 반환함
-                    FirebaseGroup.getGroups(
+                    FirebaseGroup.getGroupIds(
                             user.getIdToken(),
                             groupIdList -> {
                                 // 현재 유저가 가입되어 있는 그룹이 여러 개일 수 있으므로

--- a/app/src/main/java/com/example/woomansi/ui/viewmodel/Main1ViewModel.java
+++ b/app/src/main/java/com/example/woomansi/ui/viewmodel/Main1ViewModel.java
@@ -10,7 +10,7 @@ import com.cometj03.composetimetable.TimeTableData;
 import com.example.woomansi.data.model.ScheduleModel;
 import com.example.woomansi.data.model.UserModel;
 import com.example.woomansi.data.repository.FirebaseGroupSchedule;
-import com.example.woomansi.data.repository.FirebaseSchedules;
+import com.example.woomansi.data.repository.FirebaseUserSchedule;
 import com.example.woomansi.util.ScheduleTypeTransform;
 import com.example.woomansi.util.TimeFormatUtil;
 import com.example.woomansi.util.UserCache;
@@ -54,7 +54,7 @@ public class Main1ViewModel extends ViewModel {
                 TimeFormatUtil.timeToString(endTime),
                 color);
 
-        FirebaseSchedules.addSchedule(
+        FirebaseUserSchedule.addSchedule(
                 user.getIdToken(),
                 dayOfWeekName,
                 schedule,
@@ -96,13 +96,17 @@ public class Main1ViewModel extends ViewModel {
             });
     }
 
-    public void loadSchedules(List<String> dayNameList) {
+    public void deleteSchedule(String dayName, ScheduleModel scheduleModel) {
+        // FirebaseUserSchedule.deleteSchedule();
+    }
+
+    private void loadSchedules(List<String> dayNameList) {
         UserModel user = UserCache.getUser(null);
         if (user == null)
             return;
 
         isLoading.setValue(true);
-        FirebaseSchedules.getSchedules(
+        FirebaseUserSchedule.getSchedules(
             user.getIdToken(),
             dayNameList,
             scheduleMap -> {

--- a/app/src/main/java/com/example/woomansi/util/DayNameList.java
+++ b/app/src/main/java/com/example/woomansi/util/DayNameList.java
@@ -1,0 +1,26 @@
+package com.example.woomansi.util;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.example.woomansi.R;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DayNameList {
+    private static List<String> _dayNameList;
+
+    public static List<String> get(@NonNull Context context) {
+        if (_dayNameList == null) {
+            String[] array = context.getResources().getStringArray(R.array.day_name);
+            _dayNameList = Arrays.asList(array);
+        }
+        return _dayNameList;
+    }
+
+    public static List<String> get() {
+        return _dayNameList;
+    }
+}


### PR DESCRIPTION
## 추가된 부분
- 유저가 일정을 추가하거나 삭제하면 변경사항이 그룹 시간표에 적용되도록 구현
- 유저 시간표의 일정을 클릭했을 때 일정 정보를 확인하는 다이얼로그, 삭제할 수 있는 다이얼로그가 생성됨.
- `FirebaseGroup`
  - 현재 유저가 가입되어 있는 그룹 리스트 가져오기
  - 그룹에 유저 한 명 추가 및 탈퇴 함수

![image](https://user-images.githubusercontent.com/48352078/206098014-5da9ad49-9a60-4118-98fa-4d6923ba1db4.png)
![image](https://user-images.githubusercontent.com/48352078/206098072-a71bc508-853e-4582-87e5-839017498fdb.png)


## 자잘한 버그 수정
- 스케줄 데이터 두 번 불러와졌던 버그 수정
- 그룹 리스트 자동으로 갱신되는 기능 추가