### PR TITLE
fix: 그룹 1개 남은 상태에서 탈퇴시 adapter가 제대로 인지하지 못했던 현상 수정

### DIFF
--- a/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
+++ b/app/src/main/java/com/example/woomansi/data/repository/FirebaseGroup.java
@@ -76,12 +76,15 @@ public class FirebaseGroup {
                         f.onFailed("Data Listen Failed\n" + error.getMessage());
                         return;
                     }
-                    if (snapshot != null && !snapshot.isEmpty()) {
-                        List<GroupModel> groupModelList = new ArrayList<>();
-                        for (DocumentSnapshot doc : snapshot.getDocuments())
-                            groupModelList.add(doc.toObject(GroupModel.class));
-                        s.onSuccess(groupModelList);
+                    if (snapshot == null || snapshot.isEmpty()) {
+                        s.onSuccess(new ArrayList<>());
+                        return;
                     }
+
+                    List<GroupModel> groupModelList = new ArrayList<>();
+                    for (DocumentSnapshot doc : snapshot.getDocuments())
+                        groupModelList.add(doc.toObject(GroupModel.class));
+                    s.onSuccess(groupModelList);
                 });
     }
 

--- a/app/src/main/java/com/example/woomansi/ui/screen/main/Main2Fragment.java
+++ b/app/src/main/java/com/example/woomansi/ui/screen/main/Main2Fragment.java
@@ -142,7 +142,8 @@ public class Main2Fragment extends Fragment {
                 userId,
                 groupModelList -> {
                     groupModelArrayList = new ArrayList<>();
-                    groupModelArrayList.addAll(groupModelList);
+                    if (groupModelList.size() != 0)
+                        groupModelArrayList.addAll(groupModelList);
                     refreshAdapter();
                 },
                 errorMsg -> showToast(errorMsg)


### PR DESCRIPTION
- 그룹이 1개 남았을 때, 그룹 탈퇴시 여전히 그룹 메인화면에 그룹이 남아있던 현상 수정